### PR TITLE
Fix Bug with JobsReborn

### DIFF
--- a/plugin/src/main/java/net/momirealms/customfishing/compatibility/level/JobsRebornImpl.java
+++ b/plugin/src/main/java/net/momirealms/customfishing/compatibility/level/JobsRebornImpl.java
@@ -31,13 +31,9 @@ public class JobsRebornImpl implements LevelInterface {
     @Override
     public void addXp(Player player, String target, double amount) {
         JobsPlayer jobsPlayer = Jobs.getPlayerManager().getJobsPlayer(player);
-        if (jobsPlayer != null) {
-            List<JobProgression> jobs = jobsPlayer.getJobProgression();
-            Job job = Jobs.getJob(target);
-            for (JobProgression progression : jobs)
-                if (progression.getJob().equals(job))
-                    progression.addExperience(amount);
-        }
+        Job job = Jobs.getJob(target);
+        if (jobsPlayer != null && jobsPlayer.isInJob(job))
+            Jobs.getPlayerManager().addExperience(jobsPlayer, job, amount);
     }
 
     @Override


### PR DESCRIPTION
For some reason the JobsProgression.addExperience does not call the JobsLevelUpEvent when the player exceeds his level. This is a problem when another plugin listens for this event. I fixed it by giving it the experience from the PlayerManagement.