### PR TITLE
Add AuraSkills as a leveler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ allprojects {
         maven("https://repo.xenondevs.xyz/releases/")
         maven("https://repo.oraxen.com/releases")
         maven("https://nexus.betonquest.org/repository/betonquest/")
+        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     }
 }
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     compileOnly("pers.neige.neigeitems:NeigeItems:1.16.24")
     compileOnly("com.github.Zrips:Jobs:4.17.2")
     compileOnly("com.github.Archy-X:AureliumSkills:Beta1.3.21")
+    compileOnly("dev.aurelium:auraskills-api-bukkit:2.0.0-SNAPSHOT")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
     compileOnly("org.betonquest:betonquest:2.0.0")
     compileOnly("xyz.xenondevs.invui:invui:1.25")

--- a/plugin/src/main/java/net/momirealms/customfishing/compatibility/IntegrationManagerImpl.java
+++ b/plugin/src/main/java/net/momirealms/customfishing/compatibility/IntegrationManagerImpl.java
@@ -119,6 +119,10 @@ public class IntegrationManagerImpl implements IntegrationManager {
             registerLevelPlugin("AureliumSkills", new AureliumSkillsImpl());
             hookMessage("AureliumSkills");
         }
+        if (plugin.isHookedPluginEnabled("AuraSkills")) {
+            registerLevelPlugin("AuraSkills", new AuraSkillsImpl());
+            hookMessage("AuraSkills");
+        }
         if (plugin.isHookedPluginEnabled("EcoEnchants")) {
             this.enchantmentPluginMap.put("EcoEnchants", new VanillaEnchantmentsImpl());
             hookMessage("EcoEnchants");

--- a/plugin/src/main/java/net/momirealms/customfishing/compatibility/level/AuraSkillsImpl.java
+++ b/plugin/src/main/java/net/momirealms/customfishing/compatibility/level/AuraSkillsImpl.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) <2022> <XiaoMoMi>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.momirealms.customfishing.compatibility.level;
+
+import dev.aurelium.auraskills.api.AuraSkillsApi;
+import dev.aurelium.auraskills.api.registry.NamespacedId;
+import net.momirealms.customfishing.api.integration.LevelInterface;
+import org.bukkit.entity.Player;
+
+public class AuraSkillsImpl implements LevelInterface {
+
+    @Override
+    public void addXp(Player player, String target, double amount) {
+        AuraSkillsApi.get().getUser(player.getUniqueId())
+                .addSkillXp(AuraSkillsApi.get().getGlobalRegistry().getSkill(NamespacedId.fromDefault(target)), amount);
+    }
+
+    @Override
+    public int getLevel(Player player, String target) {
+        return AuraSkillsApi.get().getUser(player.getUniqueId()).getSkillLevel(
+                AuraSkillsApi.get().getGlobalRegistry().getSkill(NamespacedId.fromDefault(target))
+        );
+    }
+}
+

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -16,6 +16,7 @@ softdepend:
   - MMOItems
   - mcMMO
   - AureliumSkills
+  - AuraSkills
   - CustomCrops
   - MMOCore
   - EcoSkills


### PR DESCRIPTION
This pr add AuraSkills (AureliumSkills 2.0) compatibility as a leveler. AuraSkills will be released in a few days but it is stable already. You can use the dev builds and view the new wiki as well.

https://wiki.aurelium.dev/auraskills
https://aurelium.dev/auraskills/download?channel=recode

**Please test it before you merge. It should be fine though.**