### PR TITLE
fix(fr): resolve YAML parsing error for 'competition-not-exist' key

### DIFF
--- a/plugin/src/main/resources/messages/fr.yml
+++ b/plugin/src/main/resources/messages/fr.yml
@@ -9,8 +9,8 @@ messages:
   get-item: 'A obtenu avec succès {amount}x {item}.'
   possible-loots: 'Butins possibles ici : '
   split-char: ', '
-  competition-not-exist: 'La compétition {id} n'existe pas.'
-  no-competition-ongoing: "Aucune compétition en cours."
+  competition-not-exist: "La compétition {id} n'existe pas."
+  no-competition-ongoing: 'Aucune compétition en cours.'
   stop-competition: 'Compétition actuelle arrêtée.'
   end-competition: 'Compétition actuelle terminée.'
   no-score: 'Pas de score'


### PR DESCRIPTION
Correction of a YAML syntax error due to the string "La compétition {id} n'existe pas." in the 'competition-not-exist' key of the French translation file.