### PR TITLE
Fix competition player ranking loss, schedule comparison, negative Y lava detection, and market/inventory crashes

### DIFF
--- a/api/src/main/java/net/momirealms/customfishing/api/mechanic/competition/CompetitionPlayer.java
+++ b/api/src/main/java/net/momirealms/customfishing/api/mechanic/competition/CompetitionPlayer.java
@@ -102,7 +102,7 @@ public class CompetitionPlayer implements Comparable<CompetitionPlayer> {
         } else if (another.getTime() != this.time) {
             return (another.getTime() > this.time) ? 1 : -1;
         } else {
-            return 0;
+            return this.player.compareTo(another.player);
         }
     }
 

--- a/api/src/main/java/net/momirealms/customfishing/api/mechanic/competition/CompetitionSchedule.java
+++ b/api/src/main/java/net/momirealms/customfishing/api/mechanic/competition/CompetitionSchedule.java
@@ -120,6 +120,8 @@ public class CompetitionSchedule implements Comparable<CompetitionSchedule> {
             return false;
         if (minute != other.minute)
             return false;
+        if (second != other.second)
+            return false;
         return true;
     }
 

--- a/api/src/main/java/net/momirealms/customfishing/api/mechanic/fishing/hook/LavaFishingMechanic.java
+++ b/api/src/main/java/net/momirealms/customfishing/api/mechanic/fishing/hook/LavaFishingMechanic.java
@@ -77,7 +77,11 @@ public class LavaFishingMechanic implements HookMechanic {
         if (fluidData.getFluidType() == Fluid.LAVA || fluidData.getFluidType() == Fluid.FLOWING_LAVA) {
             lavaHeight = (float) (fluidData.getLevel() * 0.125);
         }
-        return lavaHeight > 0 && location.getY() % 1 <= lavaHeight;
+        double hookY = location.getY();
+        if (hookY < 0) {
+            hookY += Math.abs(Math.floor(hookY));
+        }
+        return lavaHeight > 0 && hookY % 1 <= lavaHeight;
     }
 
     @Override

--- a/api/src/main/java/net/momirealms/customfishing/api/util/InventoryUtils.java
+++ b/api/src/main/java/net/momirealms/customfishing/api/util/InventoryUtils.java
@@ -108,7 +108,7 @@ public class InventoryUtils {
                 } catch (IOException ioException) {
                     ioException.printStackTrace();
                 }
-                return null;
+                return new ItemStack[0];
             }
         }
         try {

--- a/core/src/main/java/net/momirealms/customfishing/bukkit/market/BukkitMarketManager.java
+++ b/core/src/main/java/net/momirealms/customfishing/bukkit/market/BukkitMarketManager.java
@@ -35,6 +35,7 @@ import net.momirealms.customfishing.api.mechanic.requirement.RequirementManager;
 import net.momirealms.customfishing.api.storage.data.EarningData;
 import net.momirealms.customfishing.api.storage.user.UserData;
 import net.momirealms.customfishing.api.util.EventUtils;
+import net.momirealms.customfishing.api.util.MiscUtils;
 import net.momirealms.customfishing.bukkit.config.BukkitConfigManager;
 import net.momirealms.customfishing.bukkit.item.BukkitItemFactory;
 import net.momirealms.customfishing.common.item.Item;
@@ -508,7 +509,7 @@ public class BukkitMarketManager implements MarketManager, Listener {
             return 0;
 
         Item<ItemStack> wrapped = ((BukkitItemFactory) plugin.getItemManager().getFactory()).wrap(itemStack);
-        double price = (double) wrapped.getTag("Price").orElse(0d);
+        double price = MiscUtils.getAsDouble(wrapped.getTag("Price").orElse(0d));
         if (price != 0) {
             // If a custom price is defined in the ItemStack's NBT data, use it.
             double totalPrice = price * itemStack.getAmount();


### PR DESCRIPTION
Fixed several bugs across competition ranking, scheduling, mechanics, and inventory/market parsing:
- Added player name comparison as a tie-breaker in `CompetitionPlayer.compareTo` to prevent distinct players with identical scores and timestamps from being dropped by `TreeSet`.
- Fixed `CompetitionSchedule.equals()` to include the `second` field so it remains consistent with `hashCode()` and `compareTo()`.
- Normalized Y-coordinates in `LavaFishingMechanic.canStart()` for negative Y coordinates below 0 in Minecraft 1.18+.
- Replaced unsafe primitive unboxing/casts in `BukkitMarketManager.getItemPrice()` with `MiscUtils.getAsDouble()` to prevent `ClassCastException` on integer/float NBT price tags.
- Updated `InventoryUtils.getInventoryItems()` to return an empty array instead of `null` on deserialization errors, preventing player login crashes from `Inventory.setContents(null)`.